### PR TITLE
Fix "GitHub" notation

### DIFF
--- a/contents/assets/stylesheets/styles.scss
+++ b/contents/assets/stylesheets/styles.scss
@@ -94,7 +94,7 @@ main {
 		height: auto;
 	}
 
-	// For Github ribbon
+	// For GitHub ribbon
 	img.github {
 		float: right;
 		margin-top: -$main-padding;

--- a/contents/contrib.tpl
+++ b/contents/contrib.tpl
@@ -4,17 +4,17 @@
 
 <h1>プロジェクトへの協力</h1>
 <p>
-	Hatoholはバザールモデルによるオープンな開発体制を目指していますので、プロジェクトへの貢献を歓迎します。開発のインフラとしては、主にGithubを利用していますので、基本的にはGithubを用いて参加していただくことになります。<br>
-	<a href="https://github.com/project-hatohol/hatohol/">Hatohol on Github</a>
+	Hatoholはバザールモデルによるオープンな開発体制を目指していますので、プロジェクトへの貢献を歓迎します。開発のインフラとしては、主にGitHubを利用していますので、基本的にはGitHubを用いて参加していただくことになります。<br>
+	<a href="https://github.com/project-hatohol/hatohol/">Hatohol on GitHub</a>
 </p>
 <h2>バグの報告</h2>
 <p>
-	<a href="https://github.com/project-hatohol/hatohol/issues">GithubのIssuesページ</a>から報告して下さい。報告は英語で行えるようであれば英語で行っていただくことが望ましいですが、問題が報告されないことの方が問題であると考えておりますので、日本語でも構いません。<!--詳細は<a href="https://github.com/project-hatohol/hatohol/wiki/anywhere">TODO: どこどこ</a>を参照して下さい。-->
+	<a href="https://github.com/project-hatohol/hatohol/issues">GitHubのIssuesページ</a>から報告して下さい。報告は英語で行えるようであれば英語で行っていただくことが望ましいですが、問題が報告されないことの方が問題であると考えておりますので、日本語でも構いません。<!--詳細は<a href="https://github.com/project-hatohol/hatohol/wiki/anywhere">TODO: どこどこ</a>を参照して下さい。-->
 </p>
 
 <h2>パッチの投稿</h2>
 <p>
-	Hatoholのリポジトリーをフォークし、修正をコミットした上、Github上でPull Requestを送って下さい。
+	Hatoholのリポジトリーをフォークし、修正をコミットした上、GitHub上でPull Requestを送って下さい。
 	<a href="https://github.com/project-hatohol/">https://github.com/project-hatohol/</a> 以下にあるリポジトリーに送られる全てのパッチは、Project Hatoholに寄贈されるものとなります。<!--詳細は<a href="https://github.com/project-hatohol/hatohol/wiki/somewhere">TODO: どこどこ</a>を参照して下さい。-->
 </p>
 

--- a/contents/download.tpl
+++ b/contents/download.tpl
@@ -34,7 +34,7 @@
 </ul>
 
 <h2>ソースコードをダウンロード</h2>
-		<p>ソースコードはGithubにありますので、git cloneが可能です。Ubuntuや、他のLinuxディストリビューションで試したい場合は、ソースコードからコンパイルして下さい。</p>
+		<p>ソースコードはGitHubにありますので、git cloneが可能です。Ubuntuや、他のLinuxディストリビューションで試したい場合は、ソースコードからコンパイルして下さい。</p>
 		<pre><kbd class="shell">git clone https://github.com/project-hatohol/hatohol.git</kbd></pre>
 		<p>また、以下のリンクから、最新のmasterをZip形式でダウンロードすることも可能です。</p>
 


### PR DESCRIPTION
The official "GitHub" notation is "GitHub" not "Github". See title tag
in https://github.com/.
