### PR TITLE
Fix document for SELinux permissive mode

### DIFF
--- a/contents/docs/install/14.06/ja/index.md
+++ b/contents/docs/install/14.06/ja/index.md
@@ -128,7 +128,7 @@ Webブラウザを使ったアクセス
     # getenforce
     Enforcing
 
-もし'Enforcing'であれば、次のコマンドで無効化できます。
+もし'Enforcing'であれば、次のコマンドでSELinuxポリシールールの強制を解除できます。
 
     # setenforce 0
     # getenforce


### PR DESCRIPTION
If we set 'Permissive' mode for SELinux, SELinux policy is not enforced.
But SELinux is enabled.

See below:
- https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Security-Enhanced_Linux/sect-Security-Enhanced_Linux-Working_with_SELinux-Enabling_and_Disabling_SELinux.html
