### PR TITLE
[Doc][Install] Fix typo.

### DIFF
--- a/contents/docs/install/14.09/en/index.md
+++ b/contents/docs/install/14.09/en/index.md
@@ -6,7 +6,7 @@ Installation of needed packages
 ### Register the yum repository of Project hatohol.
 Use the following command to save the repo file to /etc/yum.repos.d/ directory.
 
-    # wget -P /etc/yum.repos.d/http://project-hatohol.github.io/repo/hatohol.repo
+    # wget -P /etc/yum.repos.d/ http://project-hatohol.github.io/repo/hatohol.repo
 
 ### Register the yum repository of EPEL.
 Use the following command to add EPEL repository.
@@ -85,7 +85,7 @@ Use following commands in MySQL to create database and user.
 
 Use following command to add tables into the db.
 
-    # /usr/libexec/hatohol/client/managy.py syncdb
+    # /usr/libexec/hatohol/client/manage.py syncdb
 
 ### Start of Hatohol server
 

--- a/contents/docs/install/14.09/ja/index.md
+++ b/contents/docs/install/14.09/ja/index.md
@@ -6,7 +6,7 @@ CentOS 6.5 (x86_64)でのyumレポジトリを用いたインストール方法
 ### Project Hatohol公式yumレポジトリの登録
 以下のコマンドを実行し、Project Hatohol公式が提供するyumレポジトリの登録をしてください。
 
-    # wget -P /etc/yum.repos.d/http://project-hatohol.github.io/repo/hatohol.repo
+    # wget -P /etc/yum.repos.d/ http://project-hatohol.github.io/repo/hatohol.repo
 
 ### EPELレポジトリの登録
 以下のコマンドを実行し、EPELレポジトリの登録をしてください。
@@ -84,7 +84,7 @@ TIPS:
 
 以下のコマンドを実行してテーブルをDBの中に追加してください。
 
-    # /usr/libexec/hatohol/client/managy.py syncdb
+    # /usr/libexec/hatohol/client/manage.py syncdb
 
 ### Hatohol serverの開始
 


### PR DESCRIPTION
- Add missing space in wget command
- Fix following typo: managy.py -> manage.py
