### PR TITLE
[Index] Comment out download link.

### DIFF
--- a/contents/index.tpl
+++ b/contents/index.tpl
@@ -4,9 +4,11 @@
 	<div class="col-md-8">
 		<img class="screenshot" alt="ダッシュボード スクリーンショット" src="/assets/images/screenshots/dashboard.png">
 	</div>
+	<!--
 	<div class="col-md-4">
 		<a href="/download/" class="download download-top">ダウンロード</a>
 	</div>
+	-->
 </div>
 
 <div class="row">


### PR DESCRIPTION
I have comment out download link in index page on hatohol.org directly.
But, I didn't apply it to this source tree.

Why I've comment out, because perhaps download page will be renewal.
(If this line doesn't need, please let me know.)