### PR TITLE
Hatohol 15.06のインストール手順書の問題点の修正(Issue #37)

### DIFF
--- a/contents/docs/install/15.06/en/index.md
+++ b/contents/docs/install/15.06/en/index.md
@@ -111,10 +111,12 @@ Use following command to add tables used by Hatohol Web Frontend into the DB.
 
 ### Start of Hatohol server
 
+    # systemctl enable hatohol
     # systemctl start hatohol
 
 ### Start of Hatohol Web
 
+    # systemctl enable httpd
     # systemctl start httpd
 
 Access with a web browser
@@ -143,6 +145,7 @@ As for firewall, an allowed port can be added by executing the following command
 The following example allows port 8000.
 
     # firewall-cmd --zone=public --add-port=80/tcp --permanent
+    # firewall-cmd --zone=public --add-port=80/tcp
 
 ### View of Hatohol information
 For example, if the Hatohol Web Frontend runs on computer: 192.168.1.1,

--- a/contents/docs/install/15.06/ja/index.md
+++ b/contents/docs/install/15.06/ja/index.md
@@ -93,10 +93,12 @@ TIPS:
 
 ### Hatohol serverの開始
 
+    # systemctl enable hatohol
     # systemctl start hatohol
 
 ### Hatohol Webの開始
 
+    # systemctl enable httpd
     # systemctl start httpd
 
 Webブラウザを使ったアクセス
@@ -126,6 +128,7 @@ firewallについては、以下のコマンドを実行することで許可ポ
 以下の例は80番ポートを許可する例です。
 
     # firewall-cmd --zone=public --add-port=80/tcp --permanent
+    # firewall-cmd --zone=public --add-port=80/tcp
 
 ### Hatohol情報の閲覧
 例えば、Hatohol clientが192.168.1.1で動作している場合、


### PR DESCRIPTION
以下の2点を追加しました。

1. firewall-cmdによるポート開放は--parmanentなしコマンド列を実行するか、
--parmanent付きコマンド列実行後に firewall-cmd --reload を実行しないとポートがあかないので修正。

2.修正前の手順ではhatoholとhttpdがシステム再起動後に起動しないので、各種サービスのOS起動時に自動起動するようにsystemctl enable列を追加。