### PR TITLE
Delete link to document that becomes Error:404

### DIFF
--- a/contents/docs/index.md
+++ b/contents/docs/index.md
@@ -10,15 +10,14 @@
 
 - 0.1
 	- [インストール](/docs/install/0.1/ja/) ([English](/docs/install/0.1/en/))
-	- [アップグレード](/docs/upgrade/0.1/ja/) ([English](/docs/upgrade/0.1/en/))
 - 13.12
 	- [インストール](/docs/install/13.12/ja/) ([English](/docs/install/13.12/en/))
 	- [アップグレード](/docs/upgrade/13.12/ja/) ([English](/docs/upgrade/13.12/en/))
 - 14.03
-	- [インストール](/docs/install/14.03/ja/)([English](/docs/install/14.03/en/))
+	- [インストール](/docs/install/14.03/ja/)
 	- [アップグレード](/docs/upgrade/14.03/ja/)([English](/docs/install/14.03/en/))
 - 14.06
-	- [インストール](/docs/install/14.06/ja/)([English](/docs/install/14.06/en/))
+	- [インストール](/docs/install/14.06/ja/)
 	- [アップグレード](/docs/upgrade/14.06/ja/)([English](/docs/install/14.06/en/))
 - 14.09
 	- [インストール](/docs/install/14.09/ja/)([English](/docs/install/14.09/en/))


### PR DESCRIPTION
次のコマンドで404を探して、ハイパーリンク分のエラーを改善。
> wget --spider --recursive --no-directories --no-verbose http://www.hatohol.org/

エラーとなったURLは次の6つ。

```
http://www.hatohol.org/docs/upgrade/0.1/en/
http://www.hatohol.org/docs/upgrade/0.1/ja/
http://www.hatohol.org/docs/install/14.03/en/
http://www.hatohol.org/docs/install/14.06/en/
http://www.hatohol.org/assets/images/diagrams/distributed-monitoring.png
http://www.hatohol.org/assets/images/diagrams/integrated-monitoring.png
```

pngに関してはorgからの変換がエラーになっているのでissueを上げる。